### PR TITLE
Refactor AI Hub into modular plugin architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,93 @@
-# AI-HUB
+# AI Hub Desktop
+
+AI Hub is a PySide6 desktop companion that lives on your machine, styles itself with `pyqtdarktheme 2.1.0`, and wires global hotkeys, hotstrings, and modular AI workflows into a single window. Every capability (chat, prompts, spelling, future research tools, etc.) is packaged as its own module so you can keep stacking tabs without rewriting the core.
+
+## Highlights
+
+- **Modular tab system** – drop new modules into `src/ai_hub/modules/` (or scaffold them with `ai-hub-scaffold`) and they appear automatically.
+- **Prompt catalog with slugs** – prompts live in code or an external JSON file, can be addressed by slug, and power hotkeys, hotstrings, and the prompt navigator dialog.
+- **Global reach** – keyboard hooks run from anywhere: `Ctrl+Shift+J` fixes spelling, `Ctrl+Shift+K` opens the prompt navigator near your cursor, and `Ctrl+Alt+H` toggles hotstrings.
+- **Clipboard-safe selection helpers** – selections are copied, transformed, and pasted back without losing the user’s clipboard contents.
+- **Auto-start ready** – package with PyInstaller or register a shortcut/Scheduled Task to launch on login.
+
+## Quick Start
+
+```powershell
+py -3.11 -m venv .venv
+.venv\Scripts\activate
+pip install -e .
+setx OPENAI_API_KEY "sk-your-key"
+ai-hub
+```
+
+On macOS/Linux swap the virtual environment commands for the usual `python3 -m venv` / `source .venv/bin/activate`. The OpenAI key can also be provided through `settings.ini` (see below).
+
+### Configuration
+
+`settings.ini` (optional, stored next to the executable) understands:
+
+```ini
+[openai]
+api_key = sk-your-key
+endpoint = https://api.openai.com/v1/chat/completions
+model = gpt-4o-mini
+timeout = 120
+
+[hotkeys]
+spelling = ctrl+shift+j
+prompt_navigator = ctrl+shift+k
+goto_hub = ctrl+alt+shift+k
+toggle_hotstrings = ctrl+alt+h
+
+[hotstrings]
+enabled = true
+buffer_size = 64
+
+[paths]
+prompts = C:\\path\\to\\prompts.json
+```
+
+Environment variable overrides are also supported:
+
+- `OPENAI_API_KEY`, `OPENAI_ENDPOINT`, `OPENAI_MODEL`, `AI_HUB_TIMEOUT`
+- `AI_HUB_PROMPTS` – alternate prompt catalog JSON
+
+The prompt file expects a list of objects with `slug`, `name`, `prefix`, `suffix`, `replace`, and optional `system`, `temperature`, `order` fields.
+
+### Autostart on Windows
+
+1. Optionally package as a single EXE: `pyinstaller --noconfirm --onefile -w -n AIHub src/ai_hub/app.py`
+2. Open `shell:startup` and drop a shortcut to either the EXE or the `ai-hub` console script.
+3. Alternatively, create a Scheduled Task set to trigger “At log on” and point it at the same command.
+
+## Modules & Extensibility
+
+Modules are regular Python files that export a `register(api: ModuleAPI) -> HubModule`. At runtime the loader imports every module under `src/ai_hub/modules/`, builds the tab widget, and lets the module register hotkeys/hotstrings during its `on_init` hook.
+
+### Scaffold a new module
+
+```bash
+ai-hub-scaffold research "Research Tools" --order 40
+```
+
+This command creates `src/ai_hub/modules/research.py` with a ready-to-edit template. The `order` decides where the tab appears (lower numbers float to the left). Drop your UI in the generated factory and register any keyboard automation inside the returned `HubModule`.
+
+### Prompt-driven automation
+
+- **Prompt Navigator** – instant list of catalog prompts, bound to `Ctrl+Shift+K` by default.
+- **Hotstrings** – `;fix`, `;clar`, `;short`, and `;long` call into the catalog by slug; define new ones by adding entries to the catalog or your own module.
+- **Shortcut bindings** – `Ctrl+Alt+1/2/3` run summarize, explain, and action-item prompts. Extend via `ModuleAPI.hotkeys.register`.
+
+### Selection helpers
+
+Global operations all route through `ai_hub.services.selection`: `get_selection()` safely grabs the user’s highlight (retrying with `Ctrl+A` if empty) and `replace_selection()` pastes the result back while restoring the clipboard. Use them in your modules to stay consistent.
+
+## Roadmap Ideas
+
+- Hotstring editor tab backed by JSON/SQLite
+- FastAPI backend for long-running jobs and local model routing
+- PDF/Doc/Audio ingestion workflows
+- Tray icon with quick actions and status indicators
+- Workspace-aware profiles that switch prompts/hotkeys per app
+
+Build iteratively—add a module for each new capability, and keep your Python + UI work decoupled from the window chrome.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=67"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ai-hub"
+version = "0.1.0"
+description = "Modular desktop AI Hub with chat, prompts, spelling, hotkeys, and hotstrings."
+authors = [{name = "AI Hub"}]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "PySide6>=6.7",
+    "qdarktheme==2.1.0",
+    "requests>=2.31",
+    "keyboard>=0.13",
+    "pyperclip>=1.8; platform_system != 'Windows'",
+    "pywin32>=306; platform_system == 'Windows'",
+]
+
+[project.scripts]
+ai-hub = "ai_hub.app:main"
+ai-hub-scaffold = "ai_hub.tools.scaffold:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/ai_hub/__init__.py
+++ b/src/ai_hub/__init__.py
@@ -1,0 +1,5 @@
+"""AI Hub desktop application package."""
+
+from .app import main
+
+__all__ = ["main"]

--- a/src/ai_hub/app.py
+++ b/src/ai_hub/app.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .config import load_settings
+from .ui.main_window import run_app
+
+
+def main() -> None:
+    settings = load_settings()
+    run_app(settings)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ai_hub/config.py
+++ b/src/ai_hub/config.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import configparser
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+DEFAULT_SETTINGS_PATH = Path("settings.ini")
+
+
+@dataclass(slots=True)
+class OpenAISettings:
+    api_key: Optional[str]
+    endpoint: str
+    model: str
+    timeout: int
+
+
+@dataclass(slots=True)
+class HotkeySettings:
+    spelling: str = "ctrl+shift+j"
+    prompt_navigator: str = "ctrl+shift+k"
+    goto_hub: Optional[str] = "ctrl+alt+shift+k"
+    toggle_hotstrings: str = "ctrl+alt+h"
+
+
+@dataclass(slots=True)
+class HotstringSettings:
+    enabled_by_default: bool = True
+    buffer_size: int = 64
+
+
+@dataclass(slots=True)
+class AppSettings:
+    openai: OpenAISettings
+    hotkeys: HotkeySettings
+    hotstrings: HotstringSettings
+    paths: "PathSettings"
+
+
+@dataclass(slots=True)
+class PathSettings:
+    prompts: Optional[Path]
+
+
+_DEFAULT_ENDPOINT = "https://api.openai.com/v1/chat/completions"
+_DEFAULT_MODEL = "gpt-4o-mini"
+_DEFAULT_TIMEOUT = 120
+
+
+def _load_settings_file(path: Path) -> configparser.ConfigParser:
+    parser = configparser.ConfigParser()
+    if path.exists():
+        parser.read(path)
+    return parser
+
+
+def _read_ini_value(parser: configparser.ConfigParser, section: str, option: str, fallback: Optional[str]) -> Optional[str]:
+    if parser.has_option(section, option):
+        return parser.get(section, option)
+    return fallback
+
+
+def load_settings(settings_path: Path | None = None) -> AppSettings:
+    path = settings_path or DEFAULT_SETTINGS_PATH
+    parser = _load_settings_file(path)
+
+    api_key = os.environ.get("OPENAI_API_KEY") or _read_ini_value(parser, "openai", "api_key", None)
+    endpoint = os.environ.get("OPENAI_ENDPOINT") or _read_ini_value(parser, "openai", "endpoint", _DEFAULT_ENDPOINT) or _DEFAULT_ENDPOINT
+    model = os.environ.get("OPENAI_MODEL") or _read_ini_value(parser, "openai", "model", _DEFAULT_MODEL) or _DEFAULT_MODEL
+    timeout_str = os.environ.get("AI_HUB_TIMEOUT") or _read_ini_value(parser, "openai", "timeout", str(_DEFAULT_TIMEOUT)) or str(_DEFAULT_TIMEOUT)
+
+    hotkey_spelling = _read_ini_value(parser, "hotkeys", "spelling", HotkeySettings().spelling) or HotkeySettings().spelling
+    hotkey_prompt = _read_ini_value(parser, "hotkeys", "prompt_navigator", HotkeySettings().prompt_navigator) or HotkeySettings().prompt_navigator
+    hotkey_goto = _read_ini_value(parser, "hotkeys", "goto_hub", HotkeySettings().goto_hub)
+    hotkey_toggle = _read_ini_value(parser, "hotkeys", "toggle_hotstrings", HotkeySettings().toggle_hotstrings) or HotkeySettings().toggle_hotstrings
+
+    hotstrings_enabled = _read_ini_value(parser, "hotstrings", "enabled", None)
+    hotstrings_buffer = _read_ini_value(parser, "hotstrings", "buffer_size", str(HotstringSettings().buffer_size)) or str(HotstringSettings().buffer_size)
+
+    prompts_path_env = os.environ.get("AI_HUB_PROMPTS")
+    prompts_path_ini = _read_ini_value(parser, "paths", "prompts", prompts_path_env)
+    prompts_path = Path(prompts_path_ini).expanduser() if prompts_path_ini else None
+
+    openai_settings = OpenAISettings(
+        api_key=api_key,
+        endpoint=endpoint,
+        model=model,
+        timeout=int(timeout_str),
+    )
+    hotkey_settings = HotkeySettings(
+        spelling=hotkey_spelling,
+        prompt_navigator=hotkey_prompt,
+        goto_hub=hotkey_goto,
+        toggle_hotstrings=hotkey_toggle,
+    )
+    hotstring_settings = HotstringSettings(
+        enabled_by_default=(hotstrings_enabled.lower() == "true") if isinstance(hotstrings_enabled, str) else HotstringSettings().enabled_by_default,
+        buffer_size=int(hotstrings_buffer),
+    )
+    path_settings = PathSettings(prompts=prompts_path)
+
+    return AppSettings(
+        openai=openai_settings,
+        hotkeys=hotkey_settings,
+        hotstrings=hotstring_settings,
+        paths=path_settings,
+    )

--- a/src/ai_hub/core/context.py
+++ b/src/ai_hub/core/context.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..config import AppSettings
+from ..services.openai_client import OpenAIClient
+from ..services.prompt_manager import PromptCatalog
+
+
+@dataclass(slots=True)
+class AppContext:
+    """Shared application state exposed to modules."""
+
+    settings: AppSettings
+    client: OpenAIClient
+    prompts: PromptCatalog

--- a/src/ai_hub/hotkeys/hotstrings.py
+++ b/src/ai_hub/hotkeys/hotstrings.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+import keyboard
+
+from ..services.openai_client import OpenAIClient
+from ..services.prompt_manager import PromptCatalog
+from ..services.selection import get_selection, replace_selection
+
+
+HotstringCallback = Callable[[], None]
+
+
+@dataclass(slots=True)
+class HotstringDefinition:
+    trigger: str
+    action: Callable[[], None]
+
+
+class HotstringEngine:
+    """Simple keystroke buffer for text expanders and AI actions."""
+
+    def __init__(self, *, buffer_size: int, enabled: bool = True) -> None:
+        self._buffer_size = buffer_size
+        self._enabled = enabled
+        self._buffer: list[str] = []
+        self._text_hotstrings: dict[str, Callable[[], None]] = {}
+        self._ai_hotstrings: dict[str, Callable[[], None]] = {}
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def set_enabled(self, value: bool) -> None:
+        self._enabled = value
+
+    def register_text(self, trigger: str, replacer: Callable[[], str] | str) -> None:
+        def action() -> None:
+            text = replacer() if callable(replacer) else replacer
+            replace_selection(text)
+
+        self._text_hotstrings[trigger] = action
+
+    def register_ai(self, trigger: str, callback: HotstringCallback) -> None:
+        self._ai_hotstrings[trigger] = callback
+
+    def start(self) -> None:
+        keyboard.hook(self._on_key_event)
+
+    def _on_key_event(self, event) -> None:  # pragma: no cover - relies on OS events
+        if not self._enabled or event.event_type != "down":
+            return
+
+        key = event.name
+        if len(key) == 1:
+            self._buffer.append(key)
+        elif key == "space":
+            self._buffer.append(" ")
+        elif key == "backspace":
+            if self._buffer:
+                self._buffer.pop()
+            return
+        else:
+            return
+
+        if len(self._buffer) > self._buffer_size:
+            self._buffer = self._buffer[-self._buffer_size:]
+
+        buffer_text = "".join(self._buffer)
+
+        for trigger, action in {**self._ai_hotstrings, **self._text_hotstrings}.items():
+            if buffer_text.endswith(trigger):
+                for _ in range(len(trigger)):
+                    keyboard.send("backspace")
+                    time.sleep(0.005)
+                action()
+                self._buffer.clear()
+                break
+
+
+class AIHotstrings:
+    def __init__(self, client: OpenAIClient, catalog: PromptCatalog):
+        self._client = client
+        self._catalog = catalog
+
+    def make_handler(self, slug: str) -> Callable[[], None]:
+        def handler() -> None:
+            try:
+                prompt = self._catalog.get_by_slug(slug)
+            except KeyError:
+                return
+            selection = get_selection().text
+            if not selection.strip():
+                return
+
+            def run() -> None:
+                output = self._client.chat(prompt.system or None, prompt.build_message(selection), prompt.temperature)
+                if output.strip():
+                    replace_selection(output)
+
+            threading.Thread(target=run, daemon=True).start()
+
+        return handler

--- a/src/ai_hub/hotkeys/registry.py
+++ b/src/ai_hub/hotkeys/registry.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List
+
+import keyboard
+
+
+HotkeyCallback = Callable[[], None]
+
+
+@dataclass(slots=True)
+class HotkeyRegistration:
+    combo: str
+    callback: HotkeyCallback
+    suppress: bool = False
+    trigger_on_release: bool = True
+
+
+class HotkeyRegistry:
+    """Collects hotkeys so modules can register before hooks are active."""
+
+    def __init__(self) -> None:
+        self._registrations: List[HotkeyRegistration] = []
+        self._active = False
+
+    def register(
+        self,
+        combo: str,
+        callback: HotkeyCallback,
+        *,
+        suppress: bool = False,
+        trigger_on_release: bool = True,
+    ) -> None:
+        if self._active:
+            keyboard.add_hotkey(
+                combo,
+                callback,
+                suppress=suppress,
+                trigger_on_release=trigger_on_release,
+            )
+            return
+        self._registrations.append(
+            HotkeyRegistration(
+                combo=combo,
+                callback=callback,
+                suppress=suppress,
+                trigger_on_release=trigger_on_release,
+            )
+        )
+
+    def activate(self) -> None:
+        if self._active:
+            return
+        for registration in self._registrations:
+            keyboard.add_hotkey(
+                registration.combo,
+                registration.callback,
+                suppress=registration.suppress,
+                trigger_on_release=registration.trigger_on_release,
+            )
+        self._active = True

--- a/src/ai_hub/modules/__init__.py
+++ b/src/ai_hub/modules/__init__.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from typing import Iterable, List
+
+from .base import HubModule, ModuleAPI
+
+
+def discover_modules(api: ModuleAPI) -> List[HubModule]:
+    modules: List[HubModule] = []
+    package = __name__
+    for finder, name, ispkg in pkgutil.iter_modules(__path__, f"{package}."):
+        if ispkg:
+            continue
+        module = importlib.import_module(name)
+        register = getattr(module, "register", None)
+        if register is None:
+            continue
+        spec = register(api)
+        if isinstance(spec, Iterable):
+            modules.extend(spec)
+        else:
+            modules.append(spec)
+    return sorted(modules, key=lambda module: module.order)

--- a/src/ai_hub/modules/base.py
+++ b/src/ai_hub/modules/base.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from PySide6.QtWidgets import QWidget
+
+from ..core.context import AppContext
+from ..hotkeys.hotstrings import HotstringEngine
+from ..hotkeys.registry import HotkeyRegistry
+
+
+@dataclass(slots=True)
+class ModuleAPI:
+    """Services exposed to module registration functions."""
+
+    context: AppContext
+    hotkeys: HotkeyRegistry
+    hotstrings: HotstringEngine
+
+
+TabFactory = Callable[[ModuleAPI], QWidget]
+InitHook = Callable[[ModuleAPI], None]
+
+
+@dataclass(slots=True)
+class HubModule:
+    """Represents a tab (and optional hooks) contributed by a module."""
+
+    id: str
+    title: str
+    factory: TabFactory
+    order: int = 100
+    on_init: InitHook | None = None

--- a/src/ai_hub/modules/chat.py
+++ b/src/ai_hub/modules/chat.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from ..ui.tabs.chat_tab import ChatTab
+from .base import HubModule, ModuleAPI
+
+
+def _build_chat_tab(api: ModuleAPI) -> ChatTab:
+    return ChatTab(api.context.client)
+
+
+def register(api: ModuleAPI) -> HubModule:
+    return HubModule(
+        id="chat",
+        title="Chat",
+        factory=_build_chat_tab,
+        order=10,
+    )

--- a/src/ai_hub/modules/prompts.py
+++ b/src/ai_hub/modules/prompts.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import threading
+
+from ..hotkeys.hotstrings import AIHotstrings
+from ..services.selection import get_selection, replace_selection
+from ..ui.dialogs.prompt_navigator import PromptNavigator
+from ..ui.dialogs.result_popup import ResultPopup
+from ..ui.tabs.prompts_tab import PromptsTab
+from .base import HubModule, ModuleAPI
+
+
+PROMPT_HOTSTRINGS = {
+    ";fix": "fix",
+    ";clar": "clarity",
+    ";short": "shorten",
+    ";long": "lengthen",
+}
+
+
+def _build_prompts_tab(api: ModuleAPI) -> PromptsTab:
+    return PromptsTab(api.context.client, api.context.prompts)
+
+
+def _register_prompt_navigator(api: ModuleAPI) -> None:
+    settings = api.context.settings.hotkeys
+    navigator = PromptNavigator(api.context.client, api.context.prompts)
+
+    def show() -> None:
+        navigator.show_near_cursor()
+
+    api.hotkeys.register(settings.prompt_navigator, show)
+
+
+def _register_prompt_hotstrings(api: ModuleAPI) -> None:
+    ai_hotstrings = AIHotstrings(api.context.client, api.context.prompts)
+    for trigger, slug in PROMPT_HOTSTRINGS.items():
+        api.hotstrings.register_ai(trigger, ai_hotstrings.make_handler(slug))
+
+
+def _register_prompt_shortcuts(api: ModuleAPI) -> None:
+    catalog = api.context.prompts
+
+    def make_runner(slug: str):
+        def run() -> None:
+            try:
+                prompt = catalog.get_by_slug(slug)
+            except KeyError:
+                return
+            selection = get_selection().text
+            if not selection.strip():
+                return
+
+            def worker() -> None:
+                output = api.context.client.chat(
+                    prompt.system or None,
+                    prompt.build_message(selection),
+                    prompt.temperature,
+                )
+                if not output.strip():
+                    return
+                if prompt.replace:
+                    replace_selection(output)
+                else:
+                    ResultPopup.show_text(prompt.name, output)
+
+            threading.Thread(target=worker, daemon=True).start()
+
+        return run
+
+    # Optional quick shortcuts for summarize/explain/action items
+    shortcut_map = {
+        "ctrl+alt+1": "summarize",
+        "ctrl+alt+2": "explain",
+        "ctrl+alt+3": "action_items",
+    }
+    for combo, slug in shortcut_map.items():
+        api.hotkeys.register(combo, make_runner(slug))
+
+
+def register(api: ModuleAPI) -> HubModule:
+    def on_init(module_api: ModuleAPI) -> None:
+        _register_prompt_navigator(module_api)
+        _register_prompt_hotstrings(module_api)
+        _register_prompt_shortcuts(module_api)
+
+    return HubModule(
+        id="prompts",
+        title="Prompts",
+        factory=_build_prompts_tab,
+        order=20,
+        on_init=on_init,
+    )

--- a/src/ai_hub/modules/spelling.py
+++ b/src/ai_hub/modules/spelling.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import threading
+
+from ..services.selection import get_selection, replace_selection
+from ..ui.tabs.spelling_tab import SpellingTab
+from .base import HubModule, ModuleAPI
+
+
+def _build_spelling_tab(api: ModuleAPI) -> SpellingTab:
+    return SpellingTab(api.context.client, api.context.prompts)
+
+
+def _register_spelling_hotkey(api: ModuleAPI) -> None:
+    settings = api.context.settings.hotkeys
+
+    def run_spelling() -> None:
+        try:
+            prompt = api.context.prompts.get_by_slug("fix")
+        except KeyError:
+            return
+        selection = get_selection().text
+        if not selection.strip():
+            return
+
+        def worker() -> None:
+            output = api.context.client.chat(
+                prompt.system or None,
+                prompt.build_message(selection),
+                prompt.temperature,
+            )
+            if output.strip():
+                replace_selection(output)
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    api.hotkeys.register(settings.spelling, run_spelling)
+
+
+def register(api: ModuleAPI) -> HubModule:
+    def on_init(module_api: ModuleAPI) -> None:
+        _register_spelling_hotkey(module_api)
+
+    return HubModule(
+        id="spelling",
+        title="Spelling",
+        factory=_build_spelling_tab,
+        order=30,
+        on_init=on_init,
+    )

--- a/src/ai_hub/services/openai_client.py
+++ b/src/ai_hub/services/openai_client.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+import requests
+
+from ..config import OpenAISettings
+
+
+@dataclass(slots=True)
+class Message:
+    role: str
+    content: str
+
+
+class OpenAIClient:
+    """Thin wrapper around the Chat Completions REST API."""
+
+    def __init__(self, settings: OpenAISettings):
+        self._settings = settings
+
+    @staticmethod
+    def _build_messages(system: Optional[str], user: str) -> list[Message]:
+        messages: list[Message] = []
+        if system:
+            messages.append(Message("system", system))
+        messages.append(Message("user", user))
+        return messages
+
+    def chat(self, system: Optional[str], user: str, temperature: float = 0.2) -> str:
+        messages = self._build_messages(system, user)
+        return self._request(messages, temperature)
+
+    def _request(self, messages: Iterable[Message], temperature: float) -> str:
+        if not self._settings.api_key:
+            return "Missing OpenAI API key. Set OPENAI_API_KEY or configure settings.ini."
+
+        payload = {
+            "model": self._settings.model,
+            "messages": [msg.__dict__ for msg in messages],
+            "temperature": temperature,
+        }
+        headers = {
+            "Authorization": f"Bearer {self._settings.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            response = requests.post(
+                self._settings.endpoint,
+                headers=headers,
+                json=payload,
+                timeout=self._settings.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+        except requests.RequestException as exc:
+            return f"OpenAI request failed: {exc}"
+        except json.JSONDecodeError as exc:
+            return f"Unable to parse OpenAI response: {exc}"
+
+        choices = data.get("choices")
+        if not choices:
+            return f"Unexpected OpenAI response: {json.dumps(data, indent=2)}"
+
+        first = choices[0]
+        message = first.get("message")
+        if isinstance(message, dict) and "content" in message:
+            return str(message["content"])
+        if "text" in first:
+            return str(first["text"])
+        return f"Unexpected OpenAI response structure: {json.dumps(first, indent=2)}"

--- a/src/ai_hub/services/prompt_manager.py
+++ b/src/ai_hub/services/prompt_manager.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, Sequence
+
+
+@dataclass(slots=True)
+class Prompt:
+    """Represents a reusable instruction snippet."""
+
+    slug: str
+    name: str
+    system: str
+    prefix: str
+    suffix: str
+    replace: bool
+    temperature: float = 0.2
+    order: int = 100
+
+    def build_message(self, text: str) -> str:
+        return f"{self.prefix}{text}{self.suffix}"
+
+
+class PromptCatalog:
+    """In-memory catalog that supports lookups by slug or index."""
+
+    def __init__(self, prompts: Iterable[Prompt]):
+        ordered = sorted(prompts, key=lambda prompt: prompt.order)
+        self._prompts: list[Prompt] = ordered
+        self._index: dict[str, Prompt] = {prompt.slug: prompt for prompt in ordered}
+
+    def __iter__(self) -> Iterator[Prompt]:
+        return iter(self._prompts)
+
+    def all(self) -> list[Prompt]:
+        return list(self._prompts)
+
+    def get(self, index: int) -> Prompt:
+        return self._prompts[index]
+
+    def get_by_slug(self, slug: str) -> Prompt:
+        return self._index[slug]
+
+    def to_sequence(self) -> Sequence[Prompt]:
+        return tuple(self._prompts)
+
+    @classmethod
+    def from_path(cls, path: Path | None) -> "PromptCatalog":
+        if path and path.exists():
+            with path.open("r", encoding="utf-8") as handle:
+                raw_prompts = json.load(handle)
+            prompts = [
+                Prompt(
+                    slug=item["slug"],
+                    name=item.get("name", item["slug"].replace("_", " ").title()),
+                    system=item.get("system", ""),
+                    prefix=item.get("prefix", ""),
+                    suffix=item.get("suffix", ""),
+                    replace=bool(item.get("replace", False)),
+                    temperature=float(item.get("temperature", 0.2)),
+                    order=int(item.get("order", 100)),
+                )
+                for item in raw_prompts
+            ]
+            return cls(prompts)
+        return cls(default_prompts())
+
+
+def default_prompts() -> Sequence[Prompt]:
+    return (
+        Prompt(
+            slug="fix",
+            name="Fix spelling & grammar",
+            system="You are an English spelling corrector and grammar improver. Reply ONLY with the corrected text—no explanations.",
+            prefix="Correct the spelling (American English) and grammar of the following:\n\n",
+            suffix="",
+            replace=True,
+            temperature=0.0,
+            order=10,
+        ),
+        Prompt(
+            slug="clarity",
+            name="Rewrite for clarity",
+            system="",
+            prefix="Improve the writing for clarity and conciseness and correct spelling and grammar:\n\n",
+            suffix="",
+            replace=True,
+            order=20,
+        ),
+        Prompt(
+            slug="shorten",
+            name="Make shorter",
+            system="",
+            prefix="Make the following shorter while preserving meaning:\n\n",
+            suffix="",
+            replace=True,
+            order=30,
+        ),
+        Prompt(
+            slug="lengthen",
+            name="Make longer",
+            system="",
+            prefix="Expand the following text with more detail while staying on-topic:\n\n",
+            suffix="",
+            replace=True,
+            temperature=0.7,
+            order=40,
+        ),
+        Prompt(
+            slug="professional",
+            name="More professional",
+            system="",
+            prefix="Rewrite the following to sound professional and polished:\n\n",
+            suffix="",
+            replace=True,
+            order=50,
+        ),
+        Prompt(
+            slug="simplify",
+            name="Simplify language",
+            system="",
+            prefix="Simplify the language of the following text so it is accessible to a wide audience:\n\n",
+            suffix="",
+            replace=True,
+            order=60,
+        ),
+        Prompt(
+            slug="proofread",
+            name="Proofread (bullet suggestions)",
+            system="You are an English proofreader. Review the text and return a detailed bullet list of issues and suggested fixes with reasons.",
+            prefix="My text is the following:\n\n",
+            suffix="",
+            replace=False,
+            temperature=0.0,
+            order=70,
+        ),
+        Prompt(
+            slug="summarize",
+            name="Summarize",
+            system="",
+            prefix="Summarize the following text:\n\n",
+            suffix="",
+            replace=False,
+            order=80,
+        ),
+        Prompt(
+            slug="explain",
+            name="Explain",
+            system="",
+            prefix="Explain the following text in simple terms:\n\n",
+            suffix="",
+            replace=False,
+            order=90,
+        ),
+        Prompt(
+            slug="action_items",
+            name="Find action items",
+            system="",
+            prefix="Identify any action items in the following text and present them as bullet points after a one-sentence summary:\n\n",
+            suffix="",
+            replace=False,
+            order=100,
+        ),
+        Prompt(
+            slug="code_optimize",
+            name="Code – Optimize",
+            system="You are an assistant to a software engineer. Given code, optimize for time and space complexity and explain the changes.",
+            prefix="Improve and explain how to optimize the following code:\n\n",
+            suffix="",
+            replace=False,
+            order=110,
+        ),
+    )

--- a/src/ai_hub/services/selection.py
+++ b/src/ai_hub/services/selection.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+try:
+    import win32clipboard as wcb
+    import win32con
+    HAVE_WIN32 = True
+except Exception:  # pragma: no cover - fallback on non-Windows
+    HAVE_WIN32 = False
+
+try:
+    import pyperclip
+    HAVE_PYPERCLIP = True
+except Exception:  # pragma: no cover - optional dependency
+    HAVE_PYPERCLIP = False
+
+try:
+    import keyboard
+except ImportError as exc:  # pragma: no cover
+    raise RuntimeError("The 'keyboard' package is required for selection helpers.") from exc
+
+
+@dataclass(slots=True)
+class SelectionResult:
+    text: str
+
+
+@contextmanager
+def _preserve_clipboard():
+    original = ""
+    if HAVE_WIN32:
+        try:
+            wcb.OpenClipboard()
+            if wcb.IsClipboardFormatAvailable(win32con.CF_UNICODETEXT):
+                original = wcb.GetClipboardData(win32con.CF_UNICODETEXT)
+        finally:
+            wcb.CloseClipboard()
+    elif HAVE_PYPERCLIP:
+        original = pyperclip.paste()
+
+    try:
+        yield
+    finally:
+        if HAVE_WIN32:
+            try:
+                wcb.OpenClipboard()
+                wcb.EmptyClipboard()
+                wcb.SetClipboardText(original)
+            finally:
+                wcb.CloseClipboard()
+        elif HAVE_PYPERCLIP:
+            pyperclip.copy(original)
+
+
+def _clear_clipboard():
+    if HAVE_WIN32:
+        try:
+            wcb.OpenClipboard()
+            wcb.EmptyClipboard()
+        finally:
+            wcb.CloseClipboard()
+    elif HAVE_PYPERCLIP:
+        pyperclip.copy("")
+
+
+def _read_clipboard_text() -> str:
+    if HAVE_WIN32:
+        try:
+            wcb.OpenClipboard()
+            if wcb.IsClipboardFormatAvailable(win32con.CF_UNICODETEXT):
+                return wcb.GetClipboardData(win32con.CF_UNICODETEXT)
+        finally:
+            wcb.CloseClipboard()
+        return ""
+    if HAVE_PYPERCLIP:
+        return pyperclip.paste()
+    return ""
+
+
+def get_selection() -> SelectionResult:
+    with _preserve_clipboard():
+        _clear_clipboard()
+        keyboard.send("ctrl+c")
+        time.sleep(0.08)
+        text = _read_clipboard_text()
+        if text.strip():
+            return SelectionResult(text)
+
+        keyboard.send("ctrl+a")
+        time.sleep(0.06)
+        keyboard.send("ctrl+c")
+        time.sleep(0.08)
+        text = _read_clipboard_text()
+        return SelectionResult(text)
+
+
+def replace_selection(text: str) -> None:
+    with _preserve_clipboard():
+        if HAVE_WIN32:
+            wcb.OpenClipboard()
+            wcb.EmptyClipboard()
+            wcb.SetClipboardText(text)
+            wcb.CloseClipboard()
+        elif HAVE_PYPERCLIP:
+            pyperclip.copy(text)
+        keyboard.send("ctrl+v")
+        time.sleep(0.04)
+
+
+def copy_to_clipboard(text: str) -> None:
+    if HAVE_WIN32:
+        wcb.OpenClipboard()
+        wcb.EmptyClipboard()
+        wcb.SetClipboardText(text)
+        wcb.CloseClipboard()
+    elif HAVE_PYPERCLIP:
+        pyperclip.copy(text)

--- a/src/ai_hub/tools/scaffold.py
+++ b/src/ai_hub/tools/scaffold.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import argparse
+import textwrap
+from pathlib import Path
+
+TEMPLATE = """from __future__ import annotations
+
+from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+from ..modules.base import HubModule, ModuleAPI
+
+
+class _PlaceholderTab(QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("{title} module ready!"))
+
+
+def _build_tab(api: ModuleAPI) -> QWidget:
+    return _PlaceholderTab()
+
+
+def register(api: ModuleAPI) -> HubModule:
+    return HubModule(
+        id="{module_id}",
+        title="{title}",
+        factory=_build_tab,
+        order={order},
+    )
+"""
+
+
+def generate_module(module_name: str, title: str, order: int) -> Path:
+    target = Path(__file__).resolve().parents[1] / "modules" / f"{module_name}.py"
+    if target.exists():
+        raise SystemExit(f"Module '{module_name}' already exists at {target}.")
+    content = TEMPLATE.format(module_id=module_name, title=title, order=order)
+    target.write_text(content, encoding="utf-8")
+    return target
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="ai-hub-scaffold",
+        description="Generate a new AI Hub module skeleton.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent(
+            """
+            Examples:
+              ai-hub-scaffold research "Research Tools" --order 40
+            """
+        ),
+    )
+    parser.add_argument("name", help="Python-friendly module name (used as file + module id).")
+    parser.add_argument("title", help="Tab title shown in the UI.")
+    parser.add_argument(
+        "--order",
+        type=int,
+        default=50,
+        help="Tab order (lower numbers appear earlier).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    path = generate_module(args.name, args.title, args.order)
+    print(f"Created module at {path}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/src/ai_hub/ui/dialogs/prompt_navigator.py
+++ b/src/ai_hub/ui/dialogs/prompt_navigator.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import threading
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QCursor
+from PySide6.QtWidgets import (
+    QDialog,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QVBoxLayout,
+)
+
+from ...services.openai_client import OpenAIClient
+from ...services.prompt_manager import PromptCatalog
+from ...services.selection import get_selection, replace_selection
+from .result_popup import ResultPopup
+
+
+class PromptNavigator(QDialog):
+    def __init__(self, client: OpenAIClient, catalog: PromptCatalog):
+        super().__init__()
+        self._client = client
+        self._catalog = catalog
+        self.setWindowFlags(Qt.WindowStaysOnTopHint | Qt.Tool | Qt.FramelessWindowHint)
+        self.setWindowTitle("Prompt Navigator")
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        self.prompt_list = QListWidget(self)
+        for prompt in self._catalog:
+            item = QListWidgetItem(prompt.name, self.prompt_list)
+            item.setData(Qt.UserRole, prompt.slug)
+        layout.addWidget(self.prompt_list)
+        layout.addWidget(QLabel("Enter to run • Esc to close"))
+        self.prompt_list.itemDoubleClicked.connect(lambda _: self.run_selected())
+        self.prompt_list.setCurrentRow(0)
+
+    def show_near_cursor(self) -> None:
+        pos = QCursor.pos()
+        self.move(pos)
+        self.show()
+        self.raise_()
+        self.activateWindow()
+        self.prompt_list.setFocus()
+
+    def keyPressEvent(self, event):  # pragma: no cover - Qt
+        if event.key() in (Qt.Key_Return, Qt.Key_Enter):
+            self.run_selected()
+            return
+        if event.key() == Qt.Key_Escape:
+            self.close()
+            return
+        super().keyPressEvent(event)
+
+    def run_selected(self) -> None:
+        item = self.prompt_list.currentItem()
+        if item is None:
+            self.close()
+            return
+        slug = item.data(Qt.UserRole)
+        try:
+            prompt = self._catalog.get_by_slug(slug)
+        except KeyError:
+            self.close()
+            return
+        selection = get_selection().text
+        if not selection.strip():
+            self.close()
+            return
+
+        def run() -> None:
+            output = self._client.chat(prompt.system or None, prompt.build_message(selection), prompt.temperature)
+            if not output.strip():
+                return
+            if prompt.replace:
+                replace_selection(output)
+            else:
+                ResultPopup.show_text(prompt.name, output)
+
+        threading.Thread(target=run, daemon=True).start()
+        self.close()

--- a/src/ai_hub/ui/dialogs/result_popup.py
+++ b/src/ai_hub/ui/dialogs/result_popup.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QDialog, QPushButton, QTextEdit, QVBoxLayout
+
+from ...services.selection import copy_to_clipboard
+
+
+class ResultPopup:
+    @staticmethod
+    def show_text(title: str, content: str) -> None:
+        dialog = QDialog()
+        dialog.setWindowTitle(title)
+        dialog.setWindowFlags(Qt.WindowStaysOnTopHint | Qt.Tool)
+        layout = QVBoxLayout(dialog)
+
+        text = QTextEdit(dialog)
+        text.setReadOnly(True)
+        text.setPlainText(content)
+        layout.addWidget(text)
+
+        button = QPushButton("Copy & Close", dialog)
+        layout.addWidget(button)
+
+        def on_copy() -> None:
+            copy_to_clipboard(content)
+            dialog.accept()
+
+        button.clicked.connect(on_copy)
+        dialog.resize(680, 420)
+        dialog.exec()

--- a/src/ai_hub/ui/main_window.py
+++ b/src/ai_hub/ui/main_window.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import qdarktheme
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QApplication, QMainWindow, QTabWidget
+
+from ..config import AppSettings
+from ..core.context import AppContext
+from ..hotkeys.hotstrings import HotstringEngine
+from ..hotkeys.registry import HotkeyRegistry
+from ..modules import discover_modules
+from ..modules.base import ModuleAPI
+from ..services.openai_client import OpenAIClient
+from ..services.prompt_manager import PromptCatalog
+
+
+class MainWindow(QMainWindow):
+    def __init__(self, settings: AppSettings):
+        super().__init__()
+        self.setWindowTitle("AI Hub")
+        self.resize(1000, 720)
+
+        qdarktheme.setup_theme("auto")
+
+        self._settings = settings
+        client = OpenAIClient(settings.openai)
+        prompts = PromptCatalog.from_path(settings.paths.prompts)
+        self._context = AppContext(settings=settings, client=client, prompts=prompts)
+        self._tabs = QTabWidget(self)
+        self.setCentralWidget(self._tabs)
+
+        self._hotkey_registry = HotkeyRegistry()
+        self._hotstrings_engine = HotstringEngine(
+            buffer_size=settings.hotstrings.buffer_size,
+            enabled=settings.hotstrings.enabled_by_default,
+        )
+
+        module_api = ModuleAPI(
+            context=self._context,
+            hotkeys=self._hotkey_registry,
+            hotstrings=self._hotstrings_engine,
+        )
+        self._modules = discover_modules(module_api)
+
+        for module in self._modules:
+            widget = module.factory(module_api)
+            self._tabs.addTab(widget, module.title)
+
+        self._tabs.currentChanged.connect(self._on_tab_changed)
+
+        self._register_default_hotstrings()
+
+        if settings.hotkeys.goto_hub:
+            self._hotkey_registry.register(
+                settings.hotkeys.goto_hub,
+                self.focus_hub_tab,
+            )
+
+        for module in self._modules:
+            if module.on_init:
+                module.on_init(module_api)
+
+        self._hotstrings_engine.start()
+        self._hotkey_registry.activate()
+
+        keyboard = __import__("keyboard")
+        keyboard.add_hotkey(
+            settings.hotkeys.toggle_hotstrings,
+            self._toggle_hotstrings,
+            suppress=False,
+            trigger_on_release=True,
+        )
+
+    def _register_default_hotstrings(self) -> None:
+        import time
+
+        self._hotstrings_engine.register_text(";sig", "Best regards,\nYour Name")
+        self._hotstrings_engine.register_text(";date", lambda: time.strftime("%Y-%m-%d"))
+        self._hotstrings_engine.register_text(";time", lambda: time.strftime("%H:%M"))
+
+    def focus_hub_tab(self) -> None:
+        self.show()
+        self.raise_()
+        self.activateWindow()
+        self._tabs.setCurrentIndex(0)
+
+    def _toggle_hotstrings(self) -> None:
+        new_state = not self._hotstrings_engine.enabled
+        self._hotstrings_engine.set_enabled(new_state)
+        from PySide6.QtWidgets import QMessageBox
+
+        QMessageBox.information(self, "AI Hub", f"Hotstrings {'enabled' if new_state else 'disabled'}.")
+
+    def _on_tab_changed(self, index: int) -> None:  # pragma: no cover - UI hook
+        for i in range(self._tabs.count()):
+            widget = self._tabs.widget(i)
+            if hasattr(widget, "on_activate"):
+                if i == index:
+                    widget.on_activate()
+                else:
+                    widget.on_deactivate()
+
+
+def run_app(settings: AppSettings) -> None:
+    app = QApplication.instance() or QApplication([])
+    window = MainWindow(settings)
+    window.show()
+    app.exec()

--- a/src/ai_hub/ui/tabs/base.py
+++ b/src/ai_hub/ui/tabs/base.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from PySide6.QtWidgets import QWidget
+
+
+class Tab(Protocol):
+    widget: QWidget
+
+    def on_activate(self) -> None:  # pragma: no cover - UI hook
+        """Called when the tab becomes active."""
+
+    def on_deactivate(self) -> None:  # pragma: no cover - UI hook
+        """Called when the tab is hidden."""
+
+
+class BaseTab(QWidget):
+    """Convenience base class providing no-op activate/deactivate hooks."""
+
+    def on_activate(self) -> None:  # pragma: no cover - UI hook
+        pass
+
+    def on_deactivate(self) -> None:  # pragma: no cover - UI hook
+        pass

--- a/src/ai_hub/ui/tabs/chat_tab.py
+++ b/src/ai_hub/ui/tabs/chat_tab.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import threading
+
+from PySide6.QtCore import Signal, Slot
+from PySide6.QtWidgets import QLabel, QPushButton, QTextEdit, QVBoxLayout
+
+from ...services.openai_client import OpenAIClient
+from ..tabs.base import BaseTab
+
+
+class ChatTab(BaseTab):
+    request_started = Signal()
+    request_finished = Signal(str)
+
+    def __init__(self, client: OpenAIClient, system_default: str = "You are a helpful assistant."):
+        super().__init__()
+        self._client = client
+        self._system_default = system_default
+        self._build_ui()
+        self.request_started.connect(self._on_request_started)
+        self.request_finished.connect(self._on_request_finished)
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        layout.addWidget(QLabel("System (optional):"))
+        self.system_input = QTextEdit(self)
+        self.system_input.setFixedHeight(80)
+        self.system_input.setPlainText(self._system_default)
+        layout.addWidget(self.system_input)
+
+        layout.addWidget(QLabel("Your message:"))
+        self.user_input = QTextEdit(self)
+        self.user_input.setFixedHeight(200)
+        layout.addWidget(self.user_input)
+
+        self.send_button = QPushButton("Send", self)
+        self.send_button.clicked.connect(self._on_send_clicked)
+        layout.addWidget(self.send_button)
+
+        layout.addWidget(QLabel("Response:"))
+        self.response_output = QTextEdit(self)
+        self.response_output.setReadOnly(True)
+        layout.addWidget(self.response_output)
+
+    @Slot()
+    def _on_send_clicked(self) -> None:
+        message = self.user_input.toPlainText().strip()
+        if not message:
+            return
+        system = self.system_input.toPlainText().strip() or None
+
+        def run() -> None:
+            self.request_started.emit()
+            reply = self._client.chat(system, message)
+            self.request_finished.emit(reply)
+
+        threading.Thread(target=run, daemon=True).start()
+
+    @Slot()
+    def _on_request_started(self) -> None:
+        self.response_output.setPlainText("Thinking...")
+        self.send_button.setEnabled(False)
+
+    @Slot(str)
+    def _on_request_finished(self, reply: str) -> None:
+        self.response_output.setPlainText(reply)
+        self.send_button.setEnabled(True)

--- a/src/ai_hub/ui/tabs/prompts_tab.py
+++ b/src/ai_hub/ui/tabs/prompts_tab.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import threading
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QVBoxLayout,
+)
+
+from ...services.openai_client import OpenAIClient
+from ...services.prompt_manager import PromptCatalog
+from ...services.selection import get_selection, replace_selection
+from ..dialogs.result_popup import ResultPopup
+from ..tabs.base import BaseTab
+
+
+class PromptsTab(BaseTab):
+    def __init__(self, client: OpenAIClient, catalog: PromptCatalog):
+        super().__init__()
+        self._client = client
+        self._catalog = catalog
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Prompt Navigator — select text in any app, then choose a prompt:"))
+
+        self.prompt_list = QListWidget(self)
+        for prompt in self._catalog:
+            item = QListWidgetItem(prompt.name, self.prompt_list)
+            item.setData(Qt.UserRole, prompt.slug)
+        layout.addWidget(self.prompt_list)
+
+        self.run_button = QPushButton("Run on Selection", self)
+        self.run_button.clicked.connect(self._on_run_clicked)
+        layout.addWidget(self.run_button)
+
+    def _on_run_clicked(self) -> None:
+        item = self.prompt_list.currentItem()
+        if item is None:
+            return
+        slug = item.data(Qt.UserRole)
+        try:
+            prompt = self._catalog.get_by_slug(slug)
+        except KeyError:
+            return
+        selection = get_selection().text
+        if not selection.strip():
+            return
+
+        def run() -> None:
+            output = self._client.chat(prompt.system or None, prompt.build_message(selection), prompt.temperature)
+            if not output.strip():
+                return
+            if prompt.replace:
+                replace_selection(output)
+            else:
+                ResultPopup.show_text(prompt.name, output)
+
+        threading.Thread(target=run, daemon=True).start()

--- a/src/ai_hub/ui/tabs/spelling_tab.py
+++ b/src/ai_hub/ui/tabs/spelling_tab.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import threading
+
+from PySide6.QtWidgets import QLabel, QPushButton, QVBoxLayout
+
+from ...services.openai_client import OpenAIClient
+from ...services.prompt_manager import PromptCatalog
+from ...services.selection import get_selection, replace_selection
+from ..tabs.base import BaseTab
+
+
+class SpellingTab(BaseTab):
+    def __init__(self, client: OpenAIClient, catalog: PromptCatalog, slug: str = "fix"):
+        super().__init__()
+        self._client = client
+        self._catalog = catalog
+        self._slug = slug
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Select text in any window, then click to fix spelling:"))
+        button = QPushButton("Fix Spelling Now", self)
+        button.clicked.connect(self._on_fix_clicked)
+        layout.addWidget(button)
+        layout.addStretch(1)
+
+    def _on_fix_clicked(self) -> None:
+        selection = get_selection().text
+        if not selection.strip():
+            return
+
+        def run() -> None:
+            try:
+                prompt = self._catalog.get_by_slug(self._slug)
+            except KeyError:
+                return
+            output = self._client.chat(prompt.system or None, prompt.build_message(selection), prompt.temperature)
+            if output.strip():
+                replace_selection(output)
+
+        threading.Thread(target=run, daemon=True).start()


### PR DESCRIPTION
## Summary
- introduce a module discovery system backed by an AppContext, hotkey registry, and shared hotstring engine so each tab registers itself and its shortcuts independently
- convert the prompt service into a slugged catalog that can load from external JSON and expose those prompts across the UI, hotkeys, and hotstrings
- refresh the UI tabs and dialogs to consume the catalog, add prompt-driven shortcuts, and remove the legacy global hotkey harness
- add an ai-hub-scaffold CLI plus updated README guidance so new tabs can be generated and configured quickly

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d581f42ae483318d0cd425c5605f2c